### PR TITLE
Fix compiler warning and unsafe pin initalization in gpio_imx.c

### DIFF
--- a/platform/drivers/src/gpio_imx.c
+++ b/platform/drivers/src/gpio_imx.c
@@ -46,7 +46,7 @@
  *END**************************************************************************/
 void GPIO_Init(GPIO_Type* base, const gpio_init_config_t* initConfig)
 {
-    uint32_t pin;
+    uint32_t pin = 0;
     volatile uint32_t *icr;
 
     /* Clear Interrupt mask and edge-select for one particular GPIO */


### PR DESCRIPTION
`uint32_t pin` must be initailazed in "`0`" to safely use it in bit shift operations later